### PR TITLE
Remove base Ray image from RHOAI 2.11

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,3 +1,2 @@
 additional-images:
 - quay.io/modh/fms-hf-tuning@sha256:4ab6b17d9ef74c092fe8ff24b505ecad41a7d231c470bc4ee0cee23080976b08
-- quay.io/rhoai/ray@sha256:859f5c41d41bad1935bce455ad3732dff9d4d4c342b7155a7cd23809e85698ab


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHOAIENG-11019