### PR TITLE
Update Ray image in Distributed Workloads to use a fixed tag

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,3 +1,3 @@
 additional-images:
 - quay.io/modh/fms-hf-tuning@sha256:8edea6f0f9c4c631cdca1e1c10abf0d4b994738fde78c40d48eda216fdd382f5
-- quay.io/modh/ray@sha256:8b9e0efa3ae0e1862d66c02ffa82b80830334a5f8af12deb96d4f2f8babce5fe
+- quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06


### PR DESCRIPTION
Replaced the current SHA for the` quay.io/modh/ray:2.35.0-py39-cu121` image with the latest fixed tag `ray:2.35.0-py39-cu121-b87d9a71c34c0b79c0e7aa9d4245fe7f0065f774`'s SHA in RHOAI 2.14 additional images bundle