### PR TITLE
Add latest built training runtime cuda images with torch version 2.4.…

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -4,6 +4,7 @@ additional-images:
 - quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
 - quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
 - quay.io/modh/ray@sha256:bc46827094a29062a3631f533ea373a26cc73ed5854c7352f890c6376d5840df
-- quay.io/modh/training@sha256:0b1f2e3e7eebc5404cebbd2c4f960dc3bc40d453bcd8d33a53618baafedd6091
+- quay.io/modh/training@sha256:f64f7bba3f1020d39491ac84d40d362a52e4822bdc11a33cfff021178b7c4097
 - quay.io/modh/training@sha256:f594ed9ed2315e722eabf857308262629d802a07bf6a2c6e2e582f7b9d903797
+- quay.io/modh/training@sha256:f1b39d02cbb5554d7b86c8b294bcf4f9a7935a6235d9f1096eb9516bb245432e
 - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e


### PR DESCRIPTION
[RHOAIENG-21085](https://issues.redhat.com/browse/RHOAIENG-21085)

Note : 

```
- quay.io/modh/training@sha256:f64f7bba3f1020d39491ac84d40d362a52e4822bdc11a33cfff021178b7c4097  # Corresponds to quay.io/modh/training:py311-cuda121-torch241
- quay.io/modh/training@sha256:f594ed9ed2315e722eabf857308262629d802a07bf6a2c6e2e582f7b9d903797  # Corresponds to quay.io/modh/training:py311-rocm62-torch241 -- keeping as it is for now : ToDo
- quay.io/modh/training@sha256:f1b39d02cbb5554d7b86c8b294bcf4f9a7935a6235d9f1096eb9516bb245432e  # Corresponds to quay.io/modh/training:py311-cuda124-torch251
```

ToDo : 

- Add latest kubeflow training runtime ROCm images once built successfully with newly added Konflux components