### PR TITLE
remove python 3.9 ray images and update 3.11 images with new ray version

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,8 +1,6 @@
 additional-images:
 - quay.io/modh/fms-hf-tuning@sha256:18a871cbb1fb16766266b2fb7e1e498259543a88ffb4422ebf7ba142e5e739b4
-- quay.io/modh/ray@sha256:98642508c09b2b33e11cc321765c1f57a9935d97dfc63affc0d8a2e2d2a6c125
-- quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
-- quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
+- quay.io/modh/ray@sha256:ac401c35d29cbd920ef982775f20e86d948b81eb67e83adbbbba8b29ad33ca31 
 - quay.io/modh/ray@sha256:bc46827094a29062a3631f533ea373a26cc73ed5854c7352f890c6376d5840df
 - quay.io/modh/training@sha256:0b1f2e3e7eebc5404cebbd2c4f960dc3bc40d453bcd8d33a53618baafedd6091
 - quay.io/modh/training@sha256:f594ed9ed2315e722eabf857308262629d802a07bf6a2c6e2e582f7b9d903797


### PR DESCRIPTION
Replaced old python 3.11 image with the new 3.11 img that bumps Ray from 2.35.0 to 2.44.1, **CUDA only**

Removed rocm and cuda images for python 3.9

**Verification**
Please paste the SHAs into modh on quay and verify the correct images were removed and updated, thanks!