### PR TITLE
conf: update rocm and cuda ray images to 2.46.0

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,10 +1,10 @@
 additional-images:
 # Corresponds to quay.io/modh/fms-hf-tuning:v2.8.2
 - quay.io/modh/fms-hf-tuning@sha256:1ad46fe1a23f41f190c49ec2549c64f484c88fe220888a7a5700dd857ca243cc
-# Corresponds to quay.io/modh/ray:2.44.1-py311-cu121
-- quay.io/modh/ray@sha256:ac401c35d29cbd920ef982775f20e86d948b81eb67e83adbbbba8b29ad33ca31
-# Corresponds to quay.io/modh/ray:2.44.1-py311-rocm62
-- quay.io/modh/ray@sha256:a46a2a8b6d61f7679949d3fa3bcecc6c11381ec93620c8f4ac55b627a676abc2
+# Corresponds to quay.io/modh/ray:2.46.0-py311-cu121
+- quay.io/modh/ray@sha256:a5b7c04a14f180d7ca6d06a5697f6bb684e40a26b95a0c872cac23b552741707
+# Corresponds to quay.io/modh/ray:2.46.0-py311-rocm62
+- quay.io/modh/ray@sha256:48c7864989c8f22ef07772c698b761f5c1b58c6781e7a99518204d521bf56a4c
 # Corresponds to quay.io/modh/training:py311-cuda121-torch241
 - quay.io/modh/training@sha256:f64f7bba3f1020d39491ac84d40d362a52e4822bdc11a33cfff021178b7c4097
 # Corresponds to quay.io/modh/training:py311-cuda124-torch251


### PR DESCRIPTION
## WHAT
conf: update rocm and cuda ray images to 2.46.0

## Verification
go to quay.io. where images are pushed to and validate the SHA values are matching corresponding images