### PR TITLE
task(RHOAIENG-34228): Update ray cuda image sha for multi-arch

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -6,7 +6,7 @@ additional-images:
 # Corresponds to quay.io/modh/ray:2.47.1-py312-cu121
 - quay.io/modh/ray@sha256:23860dfe2e47bb69709b3883b08fd1a4d836ce02eaf8d0afeeafe6986d0fc8fb
 # Corresponds to quay.io/modh/ray:2.47.1-py312-cu128
-- quay.io/modh/ray@sha256:9c72e890f5c66bb2a0f0d940120539ffc875fb6fed83380cbe2eba938e8789b1
+- quay.io/modh/ray@sha256:fb6f207de63e442c67bb48955cf0584f3704281faf17b90419cfa274fdec63c5
 # Corresponds to quay.io/modh/ray:2.47.1-py311-rocm62
 - quay.io/modh/ray@sha256:6091617d45d5681058abecda57e0ee33f57b8855618e2509f1a354a20cc3403c
 # Corresponds to quay.io/modh/ray:2.47.1-py312-rocm62


### PR DESCRIPTION
Updating the Ray Python 3.12 CUDA 12.8 runtime image sha after multi-arch update.