### PR TITLE
Drop PyTorch based training images

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -11,14 +11,6 @@ additional-images:
 - quay.io/modh/ray@sha256:6091617d45d5681058abecda57e0ee33f57b8855618e2509f1a354a20cc3403c
 # Corresponds to quay.io/modh/ray:2.47.1-py312-rocm62
 - quay.io/modh/ray@sha256:f374130bf615a44d048fabbc75f4e6fb687446981383e3e815bda1dcda608964
-# Corresponds to quay.io/modh/training:py311-cuda121-torch241
-- quay.io/modh/training@sha256:f64f7bba3f1020d39491ac84d40d362a52e4822bdc11a33cfff021178b7c4097
-# Corresponds to quay.io/modh/training:py311-cuda124-torch251
-- quay.io/modh/training@sha256:1d0caea3e5d56ff7d672954b1ad511e661df9bdb364d56879961169a4ca8dae0
-# Corresponds to quay.io/modh/training:py311-rocm62-torch241
-- quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
-# Corresponds to quay.io/modh/training:py311-rocm62-torch251
-- quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
 # Corresponds to registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2
 - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
 # https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1760628791523959?thread_ts=1760619128.840349&cid=C09B6R3Q0KU


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-38047

These training images will now be referenced in the CSV.
