### PR TITLE
Drop images as they are part of CSV

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,4 +1,5 @@
 additional-images:
+# https://issues.redhat.com/browse/RHOAIENG-37682
 # Corresponds to quay.io/modh/fms-hf-tuning:v2.8.2
 - quay.io/modh/fms-hf-tuning@sha256:1ad46fe1a23f41f190c49ec2549c64f484c88fe220888a7a5700dd857ca243cc
 # Corresponds to quay.io/modh/ray:2.47.1-py311-cu121
@@ -11,21 +12,7 @@ additional-images:
 - quay.io/modh/ray@sha256:6091617d45d5681058abecda57e0ee33f57b8855618e2509f1a354a20cc3403c
 # Corresponds to quay.io/modh/ray:2.47.1-py312-rocm62
 - quay.io/modh/ray@sha256:f374130bf615a44d048fabbc75f4e6fb687446981383e3e815bda1dcda608964
-# Corresponds to quay.io/modh/training:py311-cuda121-torch241
-- quay.io/modh/training@sha256:f64f7bba3f1020d39491ac84d40d362a52e4822bdc11a33cfff021178b7c4097
-# Corresponds to quay.io/modh/training:py311-cuda124-torch251
-- quay.io/modh/training@sha256:1d0caea3e5d56ff7d672954b1ad511e661df9bdb364d56879961169a4ca8dae0
-# Corresponds to quay.io/modh/training:py311-rocm62-torch241
-- quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
-# Corresponds to quay.io/modh/training:py311-rocm62-torch251
-- quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
-# Corresponds to registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2
-- registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
-# https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1760628791523959?thread_ts=1760619128.840349&cid=C09B6R3Q0KU
-- registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
-# https://issues.redhat.com/browse/RHOAIENG-38570 https://redhat-internal.slack.com/archives/C09GK0M9YKD/p1762810329993509?thread_ts=1762809847.667869&cid=C09GK0M9YKD
-- registry.redhat.io/rhel9/postgresql-16:latest@sha256:3ffdde9a8e930b9cc95d659606487aac1d4d46691c04d2d926a49256d3aee6de
-# notebooks param.env images
+# notebooks param.env images (deprecated)
 - quay.io/modh/odh-minimal-notebook-container@sha256:2217d8a9cbf84c2bd3e6c6dc09089559e8a3905687ca3739e897c4b45e2b00b3
 - quay.io/modh/odh-minimal-notebook-container@sha256:e2296a1386e4d9756c386b4c7dc44bac6f61b99b3b894a10c9ff2d8d5602ca4e
 - quay.io/modh/odh-minimal-notebook-container@sha256:4ba72ae7f367a36030470fa4ac22eca0aab285c7c3f1c4cdcc33dc07aa522143


### PR DESCRIPTION
- Training images are now published to registry.redhat.io, and are part of CSV (https://issues.redhat.com/browse/RHOAIENG-35681)
- The other three images were hotfixes and are not required anymore
- Added notes as comment