### PR TITLE
conf: update ray images for RHOAI 2.25.1

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -1,16 +1,14 @@
 additional-images:
 # Corresponds to quay.io/modh/fms-hf-tuning:v2.8.2
 - quay.io/modh/fms-hf-tuning@sha256:1ad46fe1a23f41f190c49ec2549c64f484c88fe220888a7a5700dd857ca243cc
-# Corresponds to quay.io/modh/ray:2.47.1-py311-cu121
-- quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e
-# Corresponds to quay.io/modh/ray:2.47.1-py312-cu121
-- quay.io/modh/ray@sha256:23860dfe2e47bb69709b3883b08fd1a4d836ce02eaf8d0afeeafe6986d0fc8fb
-# Corresponds to quay.io/modh/ray:2.47.1-py312-cu128
-- quay.io/modh/ray@sha256:fb6f207de63e442c67bb48955cf0584f3704281faf17b90419cfa274fdec63c5
-# Corresponds to quay.io/modh/ray:2.47.1-py311-rocm62
-- quay.io/modh/ray@sha256:6091617d45d5681058abecda57e0ee33f57b8855618e2509f1a354a20cc3403c
-# Corresponds to quay.io/modh/ray:2.47.1-py312-rocm62
-- quay.io/modh/ray@sha256:f374130bf615a44d048fabbc75f4e6fb687446981383e3e815bda1dcda608964
+# Corresponds to quay.io/modh/ray:2.52.1-py311-cu121
+- quay.io/modh/ray@sha256:595b3acd10244e33fca1ed5469dccb08df66f470df55ae196f80e56edf35ad5a
+# Corresponds to quay.io/modh/ray:2.52.1-py312-cu128
+- quay.io/modh/ray@sha256:6b135421b6e756593a58b4df6664f82fc4b55237ca81475f2867518f15fe6d84
+# Corresponds to quay.io/modh/ray:2.52.1-py311-rocm61
+- quay.io/modh/ray@sha256:28a8745be454b0e881ce6c200599ddfcb3366b707a5b53cfa73087d599555158
+# Corresponds to quay.io/modh/ray:2.52.1-py312-rocm62
+- quay.io/modh/ray@sha256:900c35ec2fe4279b958e044c781a179c8cfe0c584e8af16e253814dba01816e6
 # Corresponds to registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2
 - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
 # https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1760628791523959?thread_ts=1760619128.840349&cid=C09B6R3Q0KU


### PR DESCRIPTION
## WHAT
conf: update ray images for RHOAI 2.25.1

## VERIFICATION
confirm that updated tags match these on quay for respective images