### PR TITLE
RHOAIENG-75980: Add Spark image for disconnected E2E tests

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -53,6 +53,8 @@ additional-images:
 - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
+# SparkOperator E2E test images (RHOAIENG-75980)
+- quay.io/opendatahub/data-processing:Spark-v4.0.1
 # 3.4 images (additional) 
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9

--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -54,7 +54,8 @@ additional-images:
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
 # SparkOperator E2E test images (RHOAIENG-75980)
-- quay.io/opendatahub/data-processing:Spark-v4.0.1
+# Corresponds to quay.io/opendatahub/data-processing:Spark-v4.0.1
+- quay.io/opendatahub/data-processing@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d
 # 3.4 images (additional) 
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9


### PR DESCRIPTION
## Problem

Jenkins E2E test `TestOdhOperator/components/group_1/sparkoperator` fails in disconnected environments with ImagePullBackOff.

**Error:**
```
Pod/spark-pi-d962a6t50h19b071kt10-driver: BackOff - Back-off pulling image "quay.io/opendatahub/data-processing:Spark-v4.0.1"
Failed to pull image: registry quay.io/opendatahub is blocked in /etc/containers/registries.conf
```

## Solution

Add `quay.io/opendatahub/data-processing:Spark-v4.0.1` to the mirror list so it's available during cluster setup for E2E tests.

## Testing

- [x] Image added to `rhoai-disconnected-images.yaml`
- [ ] Verify image exists in source registry
- [ ] Confirm image appears in next mirror sync
- [ ] E2E test passes in disconnected environment

## JIRA

https://redhat.atlassian.net/browse/RHOAIENG-75980