### PR TITLE
remove outdated ray images from dih for 3.6-ea.2

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -4,22 +4,12 @@ additional-images:
 - quay.io/modh/fms-hf-tuning@sha256:83f70e981657728ef9929fa50d06fe5c72f364e5ed41a9fc1331e99751f610e8
 # Corresponds to quay.io/modh/ray:2.52.1-py311-cu121
 - quay.io/modh/ray@sha256:595b3acd10244e33fca1ed5469dccb08df66f470df55ae196f80e56edf35ad5a
-# Corresponds to quay.io/modh/ray:2.53.0-py312-cu128
-- quay.io/modh/ray@sha256:7b9c6d524b64a07746caa7dc89e691fc40eb4c2b4e41ffde8361bcd8d3c94d68
-# Corresponds to quay.io/modh/ray:2.54.1-py312-cu128
-- quay.io/modh/ray@sha256:42fbc5d898cb9c7d202ee89308ef328838d42985ec384f2476d8f3356acd01cb
 # Corresponds to quay.io/modh/ray:2.55.1-py312-cu128
 - quay.io/modh/ray@sha256:e29b721f02896093fa8d128d7838200d42f0b3d6ae7d680c1e643e1dd469abe5
 # Corresponds to quay.io/modh/ray:2.55.1-py312-cu129-th081
 - quay.io/modh/ray@sha256:f63a015302758f805e5332605669b886e4d7ac60ec929413a2ffc19a904211c6
 # Corresponds to quay.io/modh/ray:2.52.1-py311-rocm61
 - quay.io/modh/ray@sha256:28a8745be454b0e881ce6c200599ddfcb3366b707a5b53cfa73087d599555158
-# Corresponds to quay.io/modh/ray:2.52.1-py312-rocm62
-- quay.io/modh/ray@sha256:900c35ec2fe4279b958e044c781a179c8cfe0c584e8af16e253814dba01816e6
-# Corresponds to quay.io/modh/ray:2.53.0-py312-rocm64
-- quay.io/modh/ray@sha256:4f771205ce0afc8ac69ce7c997bbae37e18d1077a3bb99b3af7ea8071884af57
-# Corresponds to quay.io/modh/ray:2.54.1-py312-rocm64
-- quay.io/modh/ray@sha256:d2af8349f4281e89915407a1439d374d8a2a763ae3f692d3663494f831a34c9b
 # Corresponds to quay.io/modh/ray:2.55.1-py312-rocm64
 - quay.io/modh/ray@sha256:31023d53c31f13fe863979426fd2b69c20856d02b749f16707926eb945edda9e
 # notebooks param.env images (deprecated)


### PR DESCRIPTION
As per [slack thread](https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1787753016970379?thread_ts=1761741888.478459&cid=C06C5MK3MT9), this PR updates the DIH for rhoai-3.6-ea.2, dropping older ray versions beyond the most recent python 3.11 and 3.12 images per each GPU accelerator. 