### PR TITLE
Clean up rhoai-disconnected-images.yaml

### DIFF
--- a/rhoai-disconnected-images.yaml
+++ b/rhoai-disconnected-images.yaml
@@ -45,9 +45,7 @@ additional-images:
 - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
 - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
-# SparkOperator E2E test images (RHOAIENG-75980)
-# Corresponds to quay.io/opendatahub/data-processing:Spark-v4.0.1
-- quay.io/opendatahub/data-processing@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d
+
 # 3.4 images (additional) 
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
 - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9


### PR DESCRIPTION
Removed commented-out SparkOperator E2E test image reference. thread https://redhat-internal.slack.com/archives/C087UJLD0FN/p1788183880130809?thread_ts=1783377065.079919&cid=C087UJLD0FN